### PR TITLE
fix(chore): add resthooks path in docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,4 @@
 !plugin-server/.eslintrc.js
 !plugin-server/.prettierrc
 !share/GeoLite2-City.mmdb
+!rest_hooks


### PR DESCRIPTION
## Problem

add resthooks path in docker ignore file

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
